### PR TITLE
Go redigo more similar with Crystal version

### DIFF
--- a/Go/go_redigo_performance.go
+++ b/Go/go_redigo_performance.go
@@ -5,7 +5,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 )
 
-const N = 1600000
+const N = 1000000
 
 func main() {
 	c, err := redis.Dial("tcp", ":6379")
@@ -18,11 +18,6 @@ func main() {
 		c.Send("SET", "foo", "bar")
 	}
 	c.Flush()
-	for i := 0; i < N; i++ {
-		_, err := redis.String(c.Receive())
-		errorHandler(err)
-	}
-	errorHandler(err)
 	fmt.Println("Done")
 }
 


### PR DESCRIPTION
Hi there - I checked your blog post http://www.stefanwille.com/2015/05/redis-clients-crystal-vs-ruby-vs-c-vs-go/ and after looking at the source codes for your Crystal and Go versions of the benchmark, I believe that the comparison is not being fair to Go.

Your[ Crystal version is very naive](https://github.com/stefanwille/redis-client-benchmarks/blob/master/Crystal/crystal_redis_performance.cr) - it just issues the SETs and bail, while in the [Go version](https://github.com/stefanwille/redis-client-benchmarks/blob/master/Go/go_redigo_performance.go) you do an extra:

1) [1.6M SETs](https://github.com/stefanwille/redis-client-benchmarks/blob/master/Go/go_redigo_performance.go#L8) instead of Crystal's [1M SETs](https://github.com/stefanwille/redis-client-benchmarks/blob/master/Crystal/crystal_redis_performance.cr#L3);
2) In the Go version you actually [fetch the results and do something with them](https://github.com/stefanwille/redis-client-benchmarks/blob/master/Go/go_redigo_performance.go#L22), another 1.6M times, while the Crystal version ignores returns;
3) In the Go version you have the extra cost of calling the [errorHandler function 1.6M times](https://github.com/stefanwille/redis-client-benchmarks/blob/master/Go/go_redigo_performance.go#L23) (although it might be the case that the Go compiler is inlining this, but not sure).
4) Same thing goes for redis.String(c.Receive()) on [line 22](https://github.com/stefanwille/redis-client-benchmarks/blob/master/Go/go_redigo_performance.go#L22) - so in your loop you're actually doing 4_800_000 function calls that you're completely omitting on the Crystal version.

I believe these (untested) changes should reflect a more fair apples-to-apples comparison between Go and Crystal.
